### PR TITLE
fix: wrong module path on pulse source in main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let source = match args.source {
 		#[cfg(feature = "pulseaudio")]
 		ScopeSource::Pulse { device, server_buffer } => {
-			input::pulse::PulseAudioSimpleDataSource::new(device.as_deref(), &args.opts, server_buffer)?
+			scope::input::pulse::PulseAudioSimpleDataSource::new(device.as_deref(), &args.opts, server_buffer)?
 		},
 
 		#[cfg(feature = "file")]


### PR DESCRIPTION
I ran into this when trying to build this project with the `pulseaudio` feature enabled.