### PR TITLE
Architectural changes allowing for different sample data formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target
+*.m4b
+*.flac
+*.mp3
+*.raw

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,7 +45,7 @@ impl App {
 			labels_color: ui.labels_color,
 			palette: ui.palette_color.clone(),
 			scale: ui.scale as f64,
-			width: source.buffer, // TODO also make bit depth customizable
+			width: source.buffer,	// TODO: this depends on impl SampleParser<T>::size()
 			samples: source.buffer,
 			sampling_rate: source.sample_rate,
 			references: !ui.no_reference,

--- a/src/input/cpal.rs
+++ b/src/input/cpal.rs
@@ -66,7 +66,6 @@ impl DefaultAudioDeviceWithCPAL {
 				tx.send(stream_to_matrix(
 					data.iter().cloned(),
 					actual_channels as usize,
-					1.,
 				))
 				.unwrap_or(())
 			},

--- a/src/input/file.rs
+++ b/src/input/file.rs
@@ -70,9 +70,8 @@ impl super::DataSource<f64> for FileSource {
 		}
 		match read_with_padding(&mut self.file, &mut self.buffer) {
 			Ok(()) => Some(stream_to_matrix(
-				self.buffer.chunks(2).map(Signed16PCM::parse),
+				Signed16PCM::parse(self.buffer.iter().copied()),
 				self.channels,
-				32768.0,
 			)),
 			Err(_e) => None, // TODO log it
 		}

--- a/src/input/file.rs
+++ b/src/input/file.rs
@@ -50,7 +50,7 @@ impl FileSource {
 		opts: &crate::cfg::SourceOptions,
 		limit_rate: bool,
 	) -> Result<Box<dyn super::DataSource<f64>>, std::io::Error> {
-		let sample_size = Signed16PCM::STATIC_SIZE.unwrap_or(4);
+		let sample_size = Signed16PCM::STATIC_SIZE.unwrap_or(4); // TODO this needs to actually point to the audio or some argument
 		let samples_per_batch = (opts.buffer * opts.channels as u32) / sample_size as u32;
 		
 		let batches_per_second = opts.sample_rate / samples_per_batch;

--- a/src/input/file.rs
+++ b/src/input/file.rs
@@ -50,7 +50,7 @@ impl FileSource {
 		opts: &crate::cfg::SourceOptions,
 		limit_rate: bool,
 	) -> Result<Box<dyn super::DataSource<f64>>, std::io::Error> {
-		let samples_per_batch = (opts.buffer * opts.channels as u32) / 2;
+		let samples_per_batch = (opts.buffer * opts.channels as u32) / 2;	//	TODO: magic #: depends on impl SampleParser<T>::size()
 		let batches_per_second = opts.sample_rate / samples_per_batch;
 		let ms_sleep = (1000 / batches_per_second) as u64;
 		Ok(Box::new(FileSource {
@@ -58,7 +58,7 @@ impl FileSource {
 			limit_rate,
 			ms_sleep,
 			file: File::open(path)?,
-			buffer: vec![0u8; opts.buffer as usize * opts.channels],
+			buffer: vec![0u8; opts.buffer as usize * opts.channels * 2],	//	TODO: magic #: provided by fix, depends on impl SampleParser<T>::size()
 		}))
 	}
 }

--- a/src/input/file.rs
+++ b/src/input/file.rs
@@ -50,15 +50,18 @@ impl FileSource {
 		opts: &crate::cfg::SourceOptions,
 		limit_rate: bool,
 	) -> Result<Box<dyn super::DataSource<f64>>, std::io::Error> {
-		let samples_per_batch = (opts.buffer * opts.channels as u32) / 2;	//	TODO: magic #: depends on impl SampleParser<T>::size()
+		let sample_size = Signed16PCM::STATIC_SIZE.unwrap_or(4);
+		let samples_per_batch = (opts.buffer * opts.channels as u32) / sample_size as u32;
+		
 		let batches_per_second = opts.sample_rate / samples_per_batch;
 		let ms_sleep = (1000 / batches_per_second) as u64;
+
 		Ok(Box::new(FileSource {
 			channels: opts.channels,
 			limit_rate,
 			ms_sleep,
 			file: File::open(path)?,
-			buffer: vec![0u8; opts.buffer as usize * opts.channels * 2],	//	TODO: magic #: provided by fix, depends on impl SampleParser<T>::size()
+			buffer: vec![0u8; opts.buffer as usize * opts.channels * sample_size],
 		}))
 	}
 }

--- a/src/input/format/mod.rs
+++ b/src/input/format/mod.rs
@@ -1,24 +1,23 @@
-pub trait SampleParser<T> {
-	fn parse(data: impl Iterator<Item = u8>) -> impl Iterator<Item = T> {
-		data.scan(Vec::with_capacity(2), |chunk, x| {
-			chunk.push(x);
-			if chunk.len() == Self::size() {
-				let val = Self::parse_one(chunk.clone()); //	not sure if this is the correct way to pass &mut
-				chunk.clear();
-
-				Some(Some(val))
-			} else { Some(None) }
-		}).flatten()
-	}
+use std::iter::from_fn;
+pub trait SampleParser<T> {	
+	const STATIC_SIZE: Option<usize> = None;
+	fn parse_next(data: &mut impl Iterator<Item = u8>) -> Option<T>;
 	
-	fn size() -> usize;	//	TODO: change this for greater flexibility, variable-length encoding BS
-	fn parse_one(chunk: Vec<u8>) -> T;
+	fn parse(data: impl Iterator<Item = u8>) -> impl Iterator<Item = T> where 
+		Self: Sized,
+	{
+		let mut source = data;
+		from_fn(move || Self::parse_next(&mut source))
+	}
 }
 
 pub struct Signed16PCM;
 impl SampleParser<f64> for Signed16PCM {
-	fn size() -> usize { size_of::<i16>() }
-	fn parse_one(chunk: Vec<u8>) -> f64 {
-		(chunk[0] as i16 | ((chunk[1] as i16) << 8)) as f64 / 32768.0
+	const STATIC_SIZE: Option<usize> = Some(std::mem::size_of::<i16>());
+	fn parse_next(data: &mut impl Iterator<Item = u8>) -> Option<f64> {
+		let b0 = data.next()?;
+		let b1 = data.next()?;
+		let raw = (b0 as u16 | ((b1 as u16) << 8)) as i16;
+		Some(raw as f64 / 32768.0)
 	}
 }

--- a/src/input/format/mod.rs
+++ b/src/input/format/mod.rs
@@ -1,18 +1,24 @@
 pub trait SampleParser<T> {
-	fn parse(data: impl Iterator<Item = u8>) -> impl Iterator<Item = T>;
-}
-
-pub struct Signed16PCM;
-impl SampleParser<f64> for Signed16PCM {
-	fn parse(data: impl Iterator<Item = u8>) -> impl Iterator<Item = f64> {
+	fn parse(data: impl Iterator<Item = u8>) -> impl Iterator<Item = T> {
 		data.scan(Vec::with_capacity(2), |chunk, x| {
 			chunk.push(x);
-			if chunk.len() == 2 {
-				let val = (chunk[0] as i16 | ((chunk[1] as i16) << 8)) as f64 / 32768.0;
+			if chunk.len() == Self::size() {
+				let val = Self::parse_one(chunk.clone()); //	not sure if this is the correct way to pass &mut
 				chunk.clear();
 
 				Some(Some(val))
 			} else { Some(None) }
 		}).flatten()
+	}
+	
+	fn size() -> usize;	//	TODO: change this for greater flexibility, variable-length encoding BS
+	fn parse_one(chunk: Vec<u8>) -> T;
+}
+
+pub struct Signed16PCM;
+impl SampleParser<f64> for Signed16PCM {
+	fn size() -> usize { size_of::<i16>() }
+	fn parse_one(chunk: Vec<u8>) -> f64 {
+		(chunk[0] as i16 | ((chunk[1] as i16) << 8)) as f64 / 32768.0
 	}
 }

--- a/src/input/format/mod.rs
+++ b/src/input/format/mod.rs
@@ -1,10 +1,18 @@
 pub trait SampleParser<T> {
-	fn parse(data: &[u8]) -> T;
+	fn parse(data: impl Iterator<Item = u8>) -> impl Iterator<Item = T>;
 }
 
 pub struct Signed16PCM;
 impl SampleParser<f64> for Signed16PCM {
-	fn parse(chunk: &[u8]) -> f64 {
-		(chunk[0] as i16 | ((chunk[1] as i16) << 8)) as f64
+	fn parse(data: impl Iterator<Item = u8>) -> impl Iterator<Item = f64> {
+		data.scan(Vec::with_capacity(2), |chunk, x| {
+			chunk.push(x);
+			if chunk.len() == 2 {
+				let val = (chunk[0] as i16 | ((chunk[1] as i16) << 8)) as f64 / 32768.0;
+				chunk.clear();
+
+				Some(Some(val))
+			} else { Some(None) }
+		}).flatten()
 	}
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -23,16 +23,15 @@ pub trait DataSource<T> {
 pub fn stream_to_matrix<I, O>(
 	stream: impl Iterator<Item = I>,
 	channels: usize,
-	norm: O,
 ) -> Matrix<O>
 where
 	I: Copy + Into<O>,
-	O: Copy + std::ops::Div<Output = O>,
+	O: Copy,
 {
 	let mut out = vec![vec![]; channels];
 	let mut channel = 0;
 	for sample in stream {
-		out[channel].push(sample.into() / norm);
+		out[channel].push(sample.into());
 		channel = (channel + 1) % channels;
 	}
 	out

--- a/src/input/pulse.rs
+++ b/src/input/pulse.rs
@@ -59,9 +59,8 @@ impl super::DataSource<f64> for PulseAudioSimpleDataSource {
 	fn recv(&mut self) -> Option<super::Matrix<f64>> {
 		match self.simple.read(&mut self.buffer) {
 			Ok(()) => Some(stream_to_matrix(
-				self.buffer.chunks(2).map(Signed16PCM::parse),
+				Signed16PCM::parse(self.buffer.iter().copied()),
 				self.channels,
-				32768.0,
 			)),
 			Err(e) => {
 				eprintln!("[!] could not receive from pulseaudio: {}", e);

--- a/src/input/pulse.rs
+++ b/src/input/pulse.rs
@@ -24,6 +24,7 @@ impl PulseAudioSimpleDataSource {
 		opts: &crate::cfg::SourceOptions,
 		server_buffer: u32,
 	) -> Result<Box<dyn super::DataSource<f64>>, PAErr> {
+		let sample_size = Signed16PCM::STATIC_SIZE.unwrap_or(4);
 		let spec = Spec {
 			format: Format::S16NE,	//	TODO: this should probably be mapped to the Signed16PCM format somehow
 			channels: opts.channels as u8,
@@ -33,7 +34,7 @@ impl PulseAudioSimpleDataSource {
 			return Err(PAErr(0)); // TODO what error number should we throw?
 		}
 		let attrs = BufferAttr {
-			maxlength: server_buffer * opts.buffer * opts.channels as u32 * 2,	//	TODO: magic #: depends on impl SampleParser<T>::size()
+			maxlength: server_buffer * opts.buffer * opts.channels * sample_size as u32,
 			fragsize: opts.buffer,
 			..Default::default()
 		};
@@ -49,7 +50,7 @@ impl PulseAudioSimpleDataSource {
 		)?;
 		Ok(Box::new(Self {
 			simple,
-			buffer: vec![0; opts.buffer as usize * opts.channels * 2],	//	TODO: magic #: depends on impl SampleParser<T>::size()
+			buffer: vec![0; opts.buffer as usize * opts.channels * sample_size],
 			channels: opts.channels,
 		}))
 	}

--- a/src/input/pulse.rs
+++ b/src/input/pulse.rs
@@ -24,7 +24,7 @@ impl PulseAudioSimpleDataSource {
 		opts: &crate::cfg::SourceOptions,
 		server_buffer: u32,
 	) -> Result<Box<dyn super::DataSource<f64>>, PAErr> {
-		let sample_size = Signed16PCM::STATIC_SIZE.unwrap_or(4);
+		let sample_size = Signed16PCM::STATIC_SIZE.unwrap_or(4); // TODO this needs to actually point to the audio or some argument
 		let spec = Spec {
 			format: Format::S16NE,	//	TODO: this should probably be mapped to the Signed16PCM format somehow
 			channels: opts.channels as u8,

--- a/src/input/pulse.rs
+++ b/src/input/pulse.rs
@@ -25,7 +25,7 @@ impl PulseAudioSimpleDataSource {
 		server_buffer: u32,
 	) -> Result<Box<dyn super::DataSource<f64>>, PAErr> {
 		let spec = Spec {
-			format: Format::S16NE, // TODO allow more formats?
+			format: Format::S16NE,	//	TODO: this should probably be mapped to the Signed16PCM format somehow
 			channels: opts.channels as u8,
 			rate: opts.sample_rate,
 		};
@@ -33,7 +33,7 @@ impl PulseAudioSimpleDataSource {
 			return Err(PAErr(0)); // TODO what error number should we throw?
 		}
 		let attrs = BufferAttr {
-			maxlength: server_buffer * opts.buffer * opts.channels as u32 * 2,
+			maxlength: server_buffer * opts.buffer * opts.channels as u32 * 2,	//	TODO: magic #: depends on impl SampleParser<T>::size()
 			fragsize: opts.buffer,
 			..Default::default()
 		};
@@ -49,7 +49,7 @@ impl PulseAudioSimpleDataSource {
 		)?;
 		Ok(Box::new(Self {
 			simple,
-			buffer: vec![0; opts.buffer as usize * opts.channels * 2],
+			buffer: vec![0; opts.buffer as usize * opts.channels * 2],	//	TODO: magic #: depends on impl SampleParser<T>::size()
 			channels: opts.channels,
 		}))
 	}


### PR DESCRIPTION
Most of this is just _building a flexible format_ to allow for different forms of sample encoding. At present the project does not have a clean way to differentiate different formats (I have not entirely fixed the problem, just pushed it down the road) and suffers from it, requiring several magic numbers to expand (or shrink) the buffer size / sample byte length.

The actual changes here are quite minor:
- Moved the normalization constant from `stream_to_matrix` into `SampleParser<T>` - this clarifies the purpose of the function and delegates _interpereting_ audio data to a location where it makes sense
- Changed the `SampleParser<T>` trait to define a `const STATIC_SIZE`, which can be used inside buffer sizing calculations. This makes buffer size dependent on the _format_ and fixes an issue with a mismatch between buffer and audio input sizing, causing half of the scope to be empty
- Moved the `parse()` functionality of structs implementing `SampleParser<T>` trait to a function from `&[u8]` to an `impl Iterator<Item = u8>`. This better accepts streamed (lazy, on-demand) data, better for streamed data, like an MPD fifo.

Tests:
- Run on a Windows 10, Windows 11, and NixOS system with 16-bit audio data. It works well enough.
<img width="1102" height="49" alt="image" src="https://github.com/user-attachments/assets/4631f1e4-e93c-44d5-88c1-d9b12aa6b8e7" />
<img width="839" height="89" alt="image" src="https://github.com/user-attachments/assets/b9d0db4f-a9d5-44bb-9469-cbc3083b409a" />
<img width="1276" height="1121" alt="image" src="https://github.com/user-attachments/assets/04a0b214-1a0e-49fd-8e06-f467b6d32b4f" />

