### PR TITLE
fix: chart legend now follow config `show_ui`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,8 +4,7 @@ use ratatui::{
 	layout::{Constraint, Rect},
 	style::{Modifier, Style},
 	symbols::Marker,
-	widgets::Chart,
-	widgets::{Cell, Row, Table},
+	widgets::{Cell, Chart, LegendPosition, Row, Table},
 	Terminal,
 };
 use std::{
@@ -131,7 +130,11 @@ impl App {
 					}
 					let chart = Chart::new(datasets.iter().map(|x| x.into()).collect())
 						.x_axis(self.current_display().axis(&self.graph, Dimension::X)) // TODO allow to have axis sometimes?
-						.y_axis(self.current_display().axis(&self.graph, Dimension::Y));
+						.y_axis(self.current_display().axis(&self.graph, Dimension::Y))
+						.legend_position(match self.graph.show_ui {
+							false => None,
+							true => Some(LegendPosition::TopRight),
+						});
 					f.render_widget(chart, size)
 				})?;
 			}


### PR DESCRIPTION
Hi :)

Chart legend (top right box with l/r or 0/1 ..) where not hiding when `show_ui` was `false`

This fixes what seems to be a bug